### PR TITLE
Print progress during the runs for promotion/demotion

### DIFF
--- a/org-admin-demote.py
+++ b/org-admin-demote.py
@@ -47,9 +47,12 @@ if __name__ == "__main__":
     with open("unmanaged_orgs.txt", "r") as f:
         unmanaged_orgs = f.read().splitlines()
 
+    # Print the total count of orgs to demote admin from
+    print("Total count of orgs to demote admin from: {}".format(len(unmanaged_orgs)))
+
     # Remove the enterprise admin running this from all of the unmanaged orgs
-    for org_id in unmanaged_orgs:
-        print("Removing from organization: {}".format(org_id))
+    for i, org_id in enumerate(unmanaged_orgs):
+        print("Removing from organization: {} [{}/{}]".format(org_id, i+1, len(unmanaged_orgs)))
         enterprises.promote_admin(
             graphql_endpoint, headers, enterprise_id, org_id, "UNAFFILIATED"
         )

--- a/org-admin-demote.py
+++ b/org-admin-demote.py
@@ -52,7 +52,11 @@ if __name__ == "__main__":
 
     # Remove the enterprise admin running this from all of the unmanaged orgs
     for i, org_id in enumerate(unmanaged_orgs):
-        print("Removing from organization: {} [{}/{}]".format(org_id, i+1, len(unmanaged_orgs)))
+        print(
+            "Removing from organization: {} [{}/{}]".format(
+                org_id, i + 1, len(unmanaged_orgs)
+            )
+        )
         enterprises.promote_admin(
             graphql_endpoint, headers, enterprise_id, org_id, "UNAFFILIATED"
         )

--- a/org-admin-promote.py
+++ b/org-admin-promote.py
@@ -48,9 +48,13 @@ if __name__ == "__main__":
     # Get the organization data, make sure it's the same length as the total count
     orgs = organizations.list_orgs(graphql_endpoint, enterprise_slug, headers)
     assert len(orgs) == total_org_count
-    
+
     # Print a little data
-    print("Total count of organizations returned by the query is: {}".format(total_org_count))
+    print(
+        "Total count of organizations returned by the query is: {}".format(
+            total_org_count
+        )
+    )
 
     # Get the enterprise ID
     enterprise_id = enterprises.get_enterprise_id(
@@ -58,10 +62,20 @@ if __name__ == "__main__":
     )
 
     # Promote enterprise admin running this to an organization owner of all orgs
-    unmanaged_orgs = [org["node"]["id"] for org in orgs if not org["node"]["viewerCanAdminister"]]
-    print("Total count of unmanaged organizations to be promoted on: {}".format(len(unmanaged_orgs)))
+    unmanaged_orgs = [
+        org["node"]["id"] for org in orgs if not org["node"]["viewerCanAdminister"]
+    ]
+    print(
+        "Total count of unmanaged organizations to be promoted on: {}".format(
+            len(unmanaged_orgs)
+        )
+    )
     for i, org_id in enumerate(unmanaged_orgs):
-        print("Promoting to owner on organization: {} [{}/{}]".format(org_id, i+1, len(unmanaged_orgs)))
+        print(
+            "Promoting to owner on organization: {} [{}/{}]".format(
+                org_id, i + 1, len(unmanaged_orgs)
+            )
+        )
         enterprises.promote_admin(
             graphql_endpoint, headers, enterprise_id, org_id, "OWNER"
         )


### PR DESCRIPTION
A small commit to print information of the overall progress of promotion and demotion to owner in orgs during runs.

Example output for `org-admin-promote.py`:
```
$ python3 org-admin-promote.py 
Total count of organizations returned by the query is: 5
Total count of unmanaged organizations to be promoted on: 3
Promoting to owner on organization: MDEyOk9yZ2FuaXphdGlvbjEz [1/3]
Promoting to owner on organization: MDEyOk9yZ2FuaXphdGlvbjE0 [2/3]
Promoting to owner on organization: MDEyOk9yZ2FuaXphdGlvbjE1 [3/3]
Total count of newly managed organizations is: 3
```
Example output for `org-admin-demote.py`
```
$ python3 org-admin-demote.py 
Total count of orgs to demote admin from: 3
Removing from organization: MDEyOk9yZ2FuaXphdGlvbjEz [1/3]
Removing from organization: MDEyOk9yZ2FuaXphdGlvbjE0 [2/3]
Removing from organization: MDEyOk9yZ2FuaXphdGlvbjE1 [3/3]
```

This comes useful when you are running this in enterprise with a big number of orgs.