### PR TITLE
org-admin-demote.py to support demoting the enterprise admin to organization member

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,31 @@
+name: Tests
+
+on:
+  push:
+    branches-ignore: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.x"]
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install dependencies
+        run: python -m pip install -r requirements.txt
+      - name: Run tests
+        run: python -m unittest discover -s tests -v

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@ Please note that this project is released with a [Contributor Code of Conduct](C
 
 1. Fork and clone the repository
 1. Configure and install the dependencies: `pip3 install -r requirements.txt`
+1. Run the tests: `python3 -m unittest discover -s tests -v`
 1. Create a new branch: `git checkout -b my-branch-name`
 1. Push to your fork and submit a pull request
 1. Pat your self on the back and wait for your pull request to be reviewed! :tada:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The scripts will give you a list of all organizations in the enterprise as a CSV
 
 1. [`org-admin-promote.py`](/org-admin-promote.py) replaces some of the functionality of [`ghe-org-admin-promote`](https://docs.github.com/en/enterprise-server@latest/admin/configuration/configuring-your-enterprise/command-line-utilities#ghe-org-admin-promote), a built-in shell command on GHES that promotes an enterprise admin to own some/all organizations in the enterprise. It also outputs a CSV file similar to the `all_organizations.csv` [report](https://docs.github.com/en/enterprise-server@latest/admin/configuration/configuring-your-enterprise/site-admin-dashboard#reports), to better inventory organizations.
 1. [`manage-sec-team.py`](/manage-sec-team.py) creates a team in each organization, assigns it the security manager role, and then adds the people you want to that team (and removes the rest).
-1. [`org-admin-demote.py`](/org-admin-demote.py) takes the text file of orgs that the user wasn't already an owner of and "un-does" that promotion to org owner. The goal is to keep the admin account's notifications uncluttered, but running this is totally optional.
+1. [`org-admin-demote.py`](/org-admin-demote.py) takes the text file of orgs that the user wasn't already an owner of and "un-does" that promotion to org owner. By default, it removes the admin from those organizations. It can instead retain the admin as an organization member, preserving security manager team membership.
 
 ## How to use it
 
@@ -47,6 +47,7 @@ The scripts will give you a list of all organizations in the enterprise as a CSV
         - This is string URL version of the enterprise identity. It's available in the enterprise admin url (for cloud and server), e.g. `https://github.com/enterprises/ENTERPRISE-SLUG-HERE`.
       - By default, a list of all of the organizations in scope, and the unmanaged set, will be output to `all_orgs.csv` and `unmanaged_orgs.txt` respectively.
         - You can use the `--orgs-csv` and `--unmanaged-orgs` arguments to place these elsewhere.
+      - For `org-admin-demote.py`, use `--target-role member` to retain the enterprise admin as an organization member after removing owner access. The default, `--target-role unaffiliated`, preserves the existing behavior and removes the admin from the organization.
     - Security manager team script:
       - Put the name of the security manager team and the team members to add in `--team-name` and `--team-members`.
       - `--sec-team-members` (and `--sec-team-members-file`) are optional. If neither is supplied, the security managers team will still be created in each organization and assigned the security manager role, but its membership will not be modified. This is useful when team membership is managed via [Team Sync](https://docs.github.com/en/enterprise-cloud@latest/organizations/organizing-members-into-teams/synchronizing-a-team-with-an-identity-provider-group).
@@ -57,12 +58,12 @@ The scripts will give you a list of all organizations in the enterprise as a CSV
 
     1. `org-admin-promote.py` to add the enterprise admin to all organizations as an owner, creating a CSV of organizations.
     1. `manage-sec-team.py` to create a security manager team on all organizations and manage the members.
-    1. `org-admin-demote.py` will remove the enterprise admin from all the organizations the previous script added them to.
+    1. `org-admin-demote.py` will remove the enterprise admin's owner access from all the organizations the promotion script added them to. It removes the admin from those organizations by default, or retains organization and security manager team membership with `--target-role member`.
 
 ## Assumptions
 
 - The security manager team isn't already an existing team that's using team sync [for enterprise](https://docs.github.com/en/enterprise-cloud@latest/admin/identity-and-access-management/using-saml-for-enterprise-iam/managing-team-synchronization-for-organizations-in-your-enterprise) or [for organizations](https://docs.github.com/en/enterprise-cloud@latest/organizations/organizing-members-into-teams/synchronizing-a-team-with-an-identity-provider-group).
-- The Enterprise admin account doing this is not intended to be part of the security managers team you are creating (that would conflict with the demotion script)
+- Because team membership requires organization membership, the default `unaffiliated` target also removes the admin from the security managers team. If the enterprise admin should remain in that team, run `org-admin-demote.py` with `--target-role member`.
 
 ## Example
 
@@ -89,6 +90,22 @@ Creating team security-managers
 Removing ghe-admin from security-managers
 ✓ Team security-managers updated as a security manager for testorg-00003
 ```
+
+### Demotion examples
+
+Remove the enterprise admin from the organizations recorded in `unmanaged_orgs.txt`:
+
+```shell
+./org-admin-demote.py ENTERPRISE_SLUG
+```
+
+Remove owner access while retaining the enterprise admin as an organization member and preserving its security manager team membership:
+
+```shell
+./org-admin-demote.py ENTERPRISE_SLUG --target-role member
+```
+
+Both modes operate only on the organization IDs recorded by `org-admin-promote.py`. The demotion script does not modify teams or team memberships directly.
 
 ## Architecture Footnotes
 

--- a/org-admin-demote.py
+++ b/org-admin-demote.py
@@ -10,18 +10,23 @@ Inputs:
 - PAT with `admin:enterprise` and `admin:org` scope, provided via --token-file or $GITHUB_TOKEN
 - Enterprise slug (the segment after /enterprises/ in the URL)
 - A newline-delimited file of organization IDs (default: unmanaged_orgs.txt)
+- Target role: unaffiliated (default) or member
 
 Outputs:
 - Prints progress lines for each organization demotion
 """
 
 from argparse import ArgumentParser
-from typing import Iterable, List
+from typing import Iterable
 from src import enterprises, util
 import logging
 
-
 LOG = logging.getLogger(__name__)
+
+TARGET_ROLES = {
+    "unaffiliated": "UNAFFILIATED",
+    "member": "DIRECT_MEMBER",
+}
 
 
 def add_args(parser: ArgumentParser) -> None:
@@ -43,7 +48,13 @@ def add_args(parser: ArgumentParser) -> None:
     parser.add_argument(
         "--unmanaged-orgs",
         default="unmanaged_orgs.txt",
-        help="Path to newline-delimited list of organization IDs to demote from (default: unmanaged_orgs.txt)",
+        help="Path to newline-delimited organization IDs from org-admin-promote.py (default: unmanaged_orgs.txt)",
+    )
+    parser.add_argument(
+        "--target-role",
+        choices=TARGET_ROLES,
+        default="unaffiliated",
+        help="Organization role after demotion (default: unaffiliated)",
     )
     parser.add_argument(
         "--progress",
@@ -71,19 +82,26 @@ def demote_admin(
     org_ids: Iterable[str],
     progress: bool = False,
     verify: str | bool | None = True,
+    target_role: str = "unaffiliated",
 ) -> None:
     """Demote the enterprise admin from each organization ID provided."""
     org_ids_list = list(org_ids)
+    graphql_role = TARGET_ROLES[target_role]
+    progress_action = (
+        "Removing from organization"
+        if target_role == "unaffiliated"
+        else "Demoting to member in organization"
+    )
     LOG.info("Total count of orgs to demote admin from: {}".format(len(org_ids_list)))
     for i, org_id in enumerate(org_ids_list):
         if progress:
             LOG.info(
-                "Removing from organization: {} [{}/{}]".format(
-                    org_id, i + 1, len(org_ids_list)
+                "{}: {} [{}/{}]".format(
+                    progress_action, org_id, i + 1, len(org_ids_list)
                 )
             )
         enterprises.promote_admin(
-            api_url, headers, enterprise_id, org_id, "UNAFFILIATED", verify=verify
+            api_url, headers, enterprise_id, org_id, graphql_role, verify=verify
         )
 
 
@@ -125,7 +143,13 @@ def main() -> None:
         return
 
     demote_admin(
-        api_url, headers, enterprise_id, unmanaged_orgs, args.progress, verify=verify
+        api_url,
+        headers,
+        enterprise_id,
+        unmanaged_orgs,
+        args.progress,
+        verify=verify,
+        target_role=args.target_role,
     )
 
 

--- a/tests/test_org_admin_demote.py
+++ b/tests/test_org_admin_demote.py
@@ -1,0 +1,147 @@
+from argparse import ArgumentParser, Namespace
+import importlib.util
+from pathlib import Path
+import sys
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+from unittest.mock import call, patch
+
+SCRIPT_PATH = Path(__file__).parents[1] / "org-admin-demote.py"
+sys.path.insert(0, str(SCRIPT_PATH.parent))
+SPEC = importlib.util.spec_from_file_location("org_admin_demote", SCRIPT_PATH)
+assert SPEC is not None
+assert SPEC.loader is not None
+org_admin_demote = importlib.util.module_from_spec(SPEC)
+try:
+    SPEC.loader.exec_module(org_admin_demote)
+finally:
+    sys.path.pop(0)
+
+
+def parse_args(*args: str) -> Namespace:
+    parser = ArgumentParser()
+    org_admin_demote.add_args(parser)
+    return parser.parse_args(["enterprise-slug", *args])
+
+
+class OrgAdminDemoteTests(TestCase):
+    def test_target_role_defaults_to_unaffiliated(self) -> None:
+        self.assertEqual(parse_args().target_role, "unaffiliated")
+
+    def test_main_processes_only_org_ids_from_unmanaged_file(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            unmanaged_orgs = Path(temp_dir) / "unmanaged_orgs.txt"
+            unmanaged_orgs.write_text("org-id-1\n\norg-id-2\n", encoding="utf-8")
+
+            with (
+                patch.object(
+                    sys,
+                    "argv",
+                    [
+                        "org-admin-demote.py",
+                        "enterprise-slug",
+                        "--unmanaged-orgs",
+                        str(unmanaged_orgs),
+                        "--target-role",
+                        "member",
+                    ],
+                ),
+                patch.object(
+                    org_admin_demote.util, "read_token", return_value="test-token"
+                ),
+                patch.object(
+                    org_admin_demote.util, "validate_ca_bundle", return_value=True
+                ),
+                patch.object(
+                    org_admin_demote.enterprises,
+                    "get_enterprise_id",
+                    return_value="enterprise-id",
+                ),
+                patch.object(
+                    org_admin_demote.enterprises, "promote_admin"
+                ) as promote_admin,
+            ):
+                org_admin_demote.main()
+
+        self.assertEqual(
+            promote_admin.call_args_list,
+            [
+                call(
+                    "https://api.github.com/graphql",
+                    {"Authorization": "token test-token"},
+                    "enterprise-id",
+                    "org-id-1",
+                    "DIRECT_MEMBER",
+                    verify=True,
+                ),
+                call(
+                    "https://api.github.com/graphql",
+                    {"Authorization": "token test-token"},
+                    "enterprise-id",
+                    "org-id-2",
+                    "DIRECT_MEMBER",
+                    verify=True,
+                ),
+            ],
+        )
+
+    def test_demote_admin_defaults_to_unaffiliated(self) -> None:
+        with patch.object(
+            org_admin_demote.enterprises, "promote_admin"
+        ) as promote_admin:
+            org_admin_demote.demote_admin(
+                "https://api.github.com/graphql",
+                {"Authorization": "token test"},
+                "enterprise-id",
+                ["org-id"],
+            )
+
+        promote_admin.assert_called_once_with(
+            "https://api.github.com/graphql",
+            {"Authorization": "token test"},
+            "enterprise-id",
+            "org-id",
+            "UNAFFILIATED",
+            verify=True,
+        )
+
+    def test_demote_admin_uses_requested_target_role(self) -> None:
+        roles = [
+            ("unaffiliated", "UNAFFILIATED"),
+            ("member", "DIRECT_MEMBER"),
+        ]
+        for target_role, graphql_role in roles:
+            with self.subTest(target_role=target_role):
+                with patch.object(
+                    org_admin_demote.enterprises, "promote_admin"
+                ) as promote_admin:
+                    org_admin_demote.demote_admin(
+                        "https://api.github.com/graphql",
+                        {"Authorization": "token test"},
+                        "enterprise-id",
+                        ["org-id-1", "org-id-2"],
+                        verify="ca.pem",
+                        target_role=target_role,
+                    )
+
+                self.assertEqual(
+                    promote_admin.call_args_list,
+                    [
+                        call(
+                            "https://api.github.com/graphql",
+                            {"Authorization": "token test"},
+                            "enterprise-id",
+                            "org-id-1",
+                            graphql_role,
+                            verify="ca.pem",
+                        ),
+                        call(
+                            "https://api.github.com/graphql",
+                            {"Authorization": "token test"},
+                            "enterprise-id",
+                            "org-id-2",
+                            graphql_role,
+                            verify="ca.pem",
+                        ),
+                    ],
+                )


### PR DESCRIPTION
This pull request introduces a new option to the `org-admin-demote.py` script, allowing users to specify whether the enterprise admin should be removed from organizations entirely or demoted to a regular member (retaining organization and security manager team membership).

closes #54 